### PR TITLE
Simplify async loading in ldtk/tiled helpers

### DIFF
--- a/examples/helpers/ldtk.rs
+++ b/examples/helpers/ldtk.rs
@@ -14,7 +14,6 @@ use bevy::{
 use bevy::{
     asset::{AssetLoader, AssetPath, LoadContext},
     prelude::*,
-    utils::BoxedFuture,
 };
 use bevy_ecs_tilemap::map::TilemapType;
 
@@ -62,46 +61,43 @@ impl AssetLoader for LdtkLoader {
     type Settings = ();
     type Error = LdtkAssetLoaderError;
 
-    #[allow(refining_impl_trait)]
-    fn load<'a>(
+    async fn load<'a>(
         &'a self,
-        reader: &'a mut Reader,
+        reader: &'a mut Reader<'_>,
         _settings: &'a Self::Settings,
-        load_context: &'a mut LoadContext,
-    ) -> BoxedFuture<'a, Result<LdtkMap, Self::Error>> {
-        Box::pin(async move {
-            let mut bytes = Vec::new();
-            reader.read_to_end(&mut bytes).await?;
+        load_context: &'a mut LoadContext<'_>,
+    ) -> Result<Self::Asset, Self::Error> {
+        let mut bytes = Vec::new();
+        reader.read_to_end(&mut bytes).await?;
 
-            let project: ldtk_rust::Project = serde_json::from_slice(&bytes).map_err(|e| {
-                std::io::Error::new(
-                    ErrorKind::Other,
-                    format!("Could not read contents of Ldtk map: {e}"),
-                )
-            })?;
-            let dependencies: Vec<(i64, AssetPath)> = project
-                .defs
-                .tilesets
-                .iter()
-                .filter_map(|tileset| {
-                    tileset.rel_path.as_ref().map(|rel_path| {
-                        (
-                            tileset.uid,
-                            load_context.path().parent().unwrap().join(rel_path).into(),
-                        )
-                    })
+        let project: ldtk_rust::Project = serde_json::from_slice(&bytes).map_err(|e| {
+            std::io::Error::new(
+                ErrorKind::Other,
+                format!("Could not read contents of Ldtk map: {e}"),
+            )
+        })?;
+        let dependencies: Vec<(i64, AssetPath)> = project
+            .defs
+            .tilesets
+            .iter()
+            .filter_map(|tileset| {
+                tileset.rel_path.as_ref().map(|rel_path| {
+                    (
+                        tileset.uid,
+                        load_context.path().parent().unwrap().join(rel_path).into(),
+                    )
                 })
-                .collect();
+            })
+            .collect();
 
-            let ldtk_map = LdtkMap {
-                project,
-                tilesets: dependencies
-                    .iter()
-                    .map(|dep| (dep.0, load_context.load(dep.1.clone())))
-                    .collect(),
-            };
-            Ok(ldtk_map)
-        })
+        let ldtk_map = LdtkMap {
+            project,
+            tilesets: dependencies
+                .iter()
+                .map(|dep| (dep.0, load_context.load(dep.1.clone())))
+                .collect(),
+        };
+        Ok(ldtk_map)
     }
 
     fn extensions(&self) -> &[&str] {

--- a/examples/helpers/tiled.rs
+++ b/examples/helpers/tiled.rs
@@ -25,7 +25,7 @@ use bevy::{
         Res, Transform, Update,
     },
     reflect::TypePath,
-    utils::{BoxedFuture, HashMap},
+    utils::HashMap,
 };
 use bevy_ecs_tilemap::prelude::*;
 
@@ -105,90 +105,87 @@ impl AssetLoader for TiledLoader {
     type Error = TiledAssetLoaderError;
 
     #[allow(refining_impl_trait)]
-    fn load<'a>(
+    async fn load<'a>(
         &'a self,
-        reader: &'a mut Reader,
+        reader: &'a mut Reader<'_>,
         _settings: &'a Self::Settings,
-        load_context: &'a mut bevy::asset::LoadContext,
-    ) -> BoxedFuture<'a, Result<Self::Asset, Self::Error>> {
-        Box::pin(async move {
-            let mut bytes = Vec::new();
-            reader.read_to_end(&mut bytes).await?;
+        load_context: &'a mut bevy::asset::LoadContext<'_>,
+    ) -> Result<Self::Asset, Self::Error> {
+        let mut bytes = Vec::new();
+        reader.read_to_end(&mut bytes).await?;
 
-            let mut loader = tiled::Loader::with_cache_and_reader(
-                tiled::DefaultResourceCache::new(),
-                BytesResourceReader::new(&bytes),
-            );
-            let map = loader.load_tmx_map(load_context.path()).map_err(|e| {
-                std::io::Error::new(ErrorKind::Other, format!("Could not load TMX map: {e}"))
-            })?;
+        let mut loader = tiled::Loader::with_cache_and_reader(
+            tiled::DefaultResourceCache::new(),
+            BytesResourceReader::new(&bytes),
+        );
+        let map = loader.load_tmx_map(load_context.path()).map_err(|e| {
+            std::io::Error::new(ErrorKind::Other, format!("Could not load TMX map: {e}"))
+        })?;
 
-            let mut tilemap_textures = HashMap::default();
-            #[cfg(not(feature = "atlas"))]
-            let mut tile_image_offsets = HashMap::default();
+        let mut tilemap_textures = HashMap::default();
+        #[cfg(not(feature = "atlas"))]
+        let mut tile_image_offsets = HashMap::default();
 
-            for (tileset_index, tileset) in map.tilesets().iter().enumerate() {
-                let tilemap_texture = match &tileset.image {
-                    None => {
-                        #[cfg(feature = "atlas")]
-                        {
-                            log::info!("Skipping image collection tileset '{}' which is incompatible with atlas feature", tileset.name);
-                            continue;
-                        }
+        for (tileset_index, tileset) in map.tilesets().iter().enumerate() {
+            let tilemap_texture = match &tileset.image {
+                None => {
+                    #[cfg(feature = "atlas")]
+                    {
+                        log::info!("Skipping image collection tileset '{}' which is incompatible with atlas feature", tileset.name);
+                        continue;
+                    }
 
-                        #[cfg(not(feature = "atlas"))]
-                        {
-                            let mut tile_images: Vec<Handle<Image>> = Vec::new();
-                            for (tile_id, tile) in tileset.tiles() {
-                                if let Some(img) = &tile.image {
-                                    // The load context path is the TMX file itself. If the file is at the root of the
-                                    // assets/ directory structure then the tmx_dir will be empty, which is fine.
-                                    let tmx_dir = load_context
-                                        .path()
-                                        .parent()
-                                        .expect("The asset load context was empty.");
-                                    let tile_path = tmx_dir.join(&img.source);
-                                    let asset_path = AssetPath::from(tile_path);
-                                    log::info!("Loading tile image from {asset_path:?} as image ({tileset_index}, {tile_id})");
-                                    let texture: Handle<Image> =
-                                        load_context.load(asset_path.clone());
-                                    tile_image_offsets
-                                        .insert((tileset_index, tile_id), tile_images.len() as u32);
-                                    tile_images.push(texture.clone());
-                                }
+                    #[cfg(not(feature = "atlas"))]
+                    {
+                        let mut tile_images: Vec<Handle<Image>> = Vec::new();
+                        for (tile_id, tile) in tileset.tiles() {
+                            if let Some(img) = &tile.image {
+                                // The load context path is the TMX file itself. If the file is at the root of the
+                                // assets/ directory structure then the tmx_dir will be empty, which is fine.
+                                let tmx_dir = load_context
+                                    .path()
+                                    .parent()
+                                    .expect("The asset load context was empty.");
+                                let tile_path = tmx_dir.join(&img.source);
+                                let asset_path = AssetPath::from(tile_path);
+                                log::info!("Loading tile image from {asset_path:?} as image ({tileset_index}, {tile_id})");
+                                let texture: Handle<Image> = load_context.load(asset_path.clone());
+                                tile_image_offsets
+                                    .insert((tileset_index, tile_id), tile_images.len() as u32);
+                                tile_images.push(texture.clone());
                             }
-
-                            TilemapTexture::Vector(tile_images)
                         }
+
+                        TilemapTexture::Vector(tile_images)
                     }
-                    Some(img) => {
-                        // The load context path is the TMX file itself. If the file is at the root of the
-                        // assets/ directory structure then the tmx_dir will be empty, which is fine.
-                        let tmx_dir = load_context
-                            .path()
-                            .parent()
-                            .expect("The asset load context was empty.");
-                        let tile_path = tmx_dir.join(&img.source);
-                        let asset_path = AssetPath::from(tile_path);
-                        let texture: Handle<Image> = load_context.load(asset_path.clone());
+                }
+                Some(img) => {
+                    // The load context path is the TMX file itself. If the file is at the root of the
+                    // assets/ directory structure then the tmx_dir will be empty, which is fine.
+                    let tmx_dir = load_context
+                        .path()
+                        .parent()
+                        .expect("The asset load context was empty.");
+                    let tile_path = tmx_dir.join(&img.source);
+                    let asset_path = AssetPath::from(tile_path);
+                    let texture: Handle<Image> = load_context.load(asset_path.clone());
 
-                        TilemapTexture::Single(texture.clone())
-                    }
-                };
-
-                tilemap_textures.insert(tileset_index, tilemap_texture);
-            }
-
-            let asset_map = TiledMap {
-                map,
-                tilemap_textures,
-                #[cfg(not(feature = "atlas"))]
-                tile_image_offsets,
+                    TilemapTexture::Single(texture.clone())
+                }
             };
 
-            log::info!("Loaded map: {}", load_context.path().display());
-            Ok(asset_map)
-        })
+            tilemap_textures.insert(tileset_index, tilemap_texture);
+        }
+
+        let asset_map = TiledMap {
+            map,
+            tilemap_textures,
+            #[cfg(not(feature = "atlas"))]
+            tile_image_offsets,
+        };
+
+        log::info!("Loaded map: {}", load_context.path().display());
+        Ok(asset_map)
     }
 
     fn extensions(&self) -> &[&str] {

--- a/examples/helpers/tiled.rs
+++ b/examples/helpers/tiled.rs
@@ -104,7 +104,6 @@ impl AssetLoader for TiledLoader {
     type Settings = ();
     type Error = TiledAssetLoaderError;
 
-    #[allow(refining_impl_trait)]
     async fn load<'a>(
         &'a self,
         reader: &'a mut Reader<'_>,


### PR DESCRIPTION
I missed the `#[allow(refining_impl_trait)]` change previously, and remembered that something happened this cycle with async asset loading.

It looks like these loaders can be simplified now. Diff is mostly whitespace.

See [Bevy #12550](https://github.com/bevyengine/bevy/pull/12550)